### PR TITLE
fix(gui): Check if UI is initiated on destroyal

### DIFF
--- a/scripts/gui.lua
+++ b/scripts/gui.lua
@@ -290,6 +290,9 @@ end
 
 --- @param player LuaPlayer
 local function destroy_gui(player)
+  if not storage.gui then
+    return
+  end
   local self = storage.gui[player.index]
   if not self then
     return


### PR DESCRIPTION
Fixes migrating saves as configuration get's changed without a GUI being initialized